### PR TITLE
🐛 fix: 修复datepicker组件传入maxDate时, 分钟列表缺少最大分钟数的Item(如12:30却只生成了12:00)

### DIFF
--- a/components/DatePicker/components/DatePicker.tsx
+++ b/components/DatePicker/components/DatePicker.tsx
@@ -245,6 +245,7 @@ export default class DatePicker extends React.Component<DatePickerProps, DatePic
     }
 
     render(): JSX.Element {
+        // @ts-ignore
         const { prefixCls, className, style, visible, maskClose, renderCallback, title, buttonText, lang, warningText , hourUnit} = this.props;
         const cls = classnames(
             className,

--- a/components/DatePicker/util/pickerData.ts
+++ b/components/DatePicker/util/pickerData.ts
@@ -324,7 +324,7 @@ export function setMinuteListData ( currDateData, minuteStep, calcMinDate, calcM
         step = maxMinute === 0 ? 1 : Math.ceil( maxMinute / minuteStep );
         // 默认为最后一个
         minuteListData.selectIndex = step - 1;
-        for ( let i = startMinute; i < step; i++ ) {
+        for ( let i = startMinute; i <= step; i++ ) {
             if ( minuteText <= maxMinute ) {
                 if ( curMinute == i + 1 ) {
                     minuteListData.selectIndex = i;

--- a/lib/DatePicker/components/DatePicker.js
+++ b/lib/DatePicker/components/DatePicker.js
@@ -339,6 +339,7 @@ var DatePicker = function (_React$Component) {
     }, {
         key: 'render',
         value: function render() {
+            // @ts-ignore
             var _props5 = this.props,
                 prefixCls = _props5.prefixCls,
                 className = _props5.className,

--- a/lib/DatePicker/util/pickerData.js
+++ b/lib/DatePicker/util/pickerData.js
@@ -372,7 +372,7 @@ function setMinuteListData(currDateData, minuteStep, calcMinDate, calcMaxDate, l
         step = maxMinute === 0 ? 1 : Math.ceil(maxMinute / minuteStep);
         // 默认为最后一个
         minuteListData.selectIndex = step - 1;
-        for (var _i8 = _startMinute; _i8 < step; _i8++) {
+        for (var _i8 = _startMinute; _i8 <= step; _i8++) {
             if (minuteText <= maxMinute) {
                 if (curMinute == _i8 + 1) {
                     minuteListData.selectIndex = _i8;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zzc-design-mobile",
   "name_cn": "租租车主流程UI规范",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "description": "",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
当组件为 DateTime 时,  传入 maxDate = 2024/11/5 12:30, 分钟的筛选列表理应生成 0分, 30分(30为一个单位), 但只生成了12:00,分钟缺少了30, 